### PR TITLE
Added Mac-specific building flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,18 @@
 
           'cflags_cc!': ['-fno-rtti','-fno-exceptions'],
           'cflags_cc+': ['-frtti','-fno-exceptions'],
+          'conditions': [
+            ['OS=="mac"', {
+              'xcode_settings': {
+                "MACOSX_DEPLOYMENT_TARGET": "10.7",
+                "OTHER_CPLUSPLUSFLAGS": [
+                  "-stdlib=libc++"
+                ],
+                'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                'GCC_ENABLE_CPP_RTTI': 'YES'
+              }
+            }]
+          ]
           }
   ]
 }


### PR DESCRIPTION
This should fix #1.

---

'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
fixes this compilation error:
error: cannot use 'throw' with exceptions disabled

'GCC_ENABLE_CPP_RTTI': 'YES'
fixes this compilation error:
cannot use typeid with -fno-rtti" issue

"MACOSX_DEPLOYMENT_TARGET": "10.7",
"OTHER_CPLUSPLUSFLAGS": [
    "-stdlib=libc++"
]
fixes a runtime linking error. here is a sample message that was displayed:
dyld: lazy symbol binding failed: Symbol not found
